### PR TITLE
add sticky to table header on data table

### DIFF
--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -4,11 +4,9 @@ import {
 	getCoreRowModel,
 	useReactTable,
 } from '@tanstack/react-table'
-// import { ScrollArea, ScrollBar } from './scroll-area'
 import { cn } from '@/utils/cn'
-import { ChevronLeftIcon, ChevronRightIcon, Loader2 } from 'lucide-react'
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
 import { Button } from './button'
-import { ScrollArea, ScrollBar } from './scroll-area'
 import {
 	Table,
 	TableBody,
@@ -47,19 +45,45 @@ export function DataTable<TData, TValue>({
 		getCoreRowModel: getCoreRowModel(),
 	})
 
+	const renderTableBody = () => {
+		if (isLoading) {
+			return (
+				<TableRow>
+					<TableCell colSpan={columns.length} className='h-24 text-center'>
+						Loading...
+					</TableCell>
+				</TableRow>
+			)
+		}
+
+		if (table.getRowModel().rows?.length) {
+			return table.getRowModel().rows.map(row => (
+				<TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
+					{row.getVisibleCells().map(cell => (
+						<TableCell key={cell.id}>
+							{flexRender(cell.column.columnDef.cell, cell.getContext())}
+						</TableCell>
+					))}
+				</TableRow>
+			))
+		}
+
+		return (
+			<TableRow>
+				<TableCell colSpan={columns.length} className={cn('h-24 text-center')}>
+					No results.
+				</TableCell>
+			</TableRow>
+		)
+	}
+
 	return (
 		<>
-			{/* <ScrollArea className='rounded-md border h-[calc(80vh-220px)]'> */}
-			{isLoading ? (
-				<div className={cn('flex items-center justify-center h-64')}>
-					<Loader2 className={cn('h-10 w-10 animate-spin')} />
-				</div>
-			) : (
-				<div className={cn('rounded border')}>
-					<ScrollArea
-						className={cn('overflow-y-scroll max-h-[calc(80vh-220px)]')}>
-						<Table className={cn('relative')}>
-							<TableHeader>
+			<div className='w-full'>
+				<div className='rounded border'>
+					<div className='max-h-[calc(90vh-220px)] relative overflow-auto'>
+						<Table>
+							<TableHeader className='sticky top-0 bg-secondary'>
 								{table.getHeaderGroups().map(headerGroup => (
 									<TableRow key={headerGroup.id}>
 										{headerGroup.headers.map(header => {
@@ -77,39 +101,11 @@ export function DataTable<TData, TValue>({
 									</TableRow>
 								))}
 							</TableHeader>
-							<TableBody>
-								{table.getRowModel().rows?.length ? (
-									table.getRowModel().rows.map(row => (
-										<TableRow
-											key={row.id}
-											data-state={row.getIsSelected() && 'selected'}>
-											{row.getVisibleCells().map(cell => (
-												<TableCell key={cell.id}>
-													{flexRender(
-														cell.column.columnDef.cell,
-														cell.getContext()
-													)}
-												</TableCell>
-											))}
-										</TableRow>
-									))
-								) : (
-									<TableRow>
-										<TableCell
-											colSpan={columns.length}
-											className={cn('h-24 text-center')}>
-											No results.
-										</TableCell>
-									</TableRow>
-								)}
-							</TableBody>
+							<TableBody>{renderTableBody()}</TableBody>
 						</Table>
-						<ScrollBar orientation='horizontal' />
-					</ScrollArea>
+					</div>
 				</div>
-			)}
-			{/* <ScrollBar orientation='horizontal' />
-			</ScrollArea> */}
+			</div>
 			<div
 				className={cn(
 					'flex flex-col gap-2 sm:flex-row items-center justify-end space-x-2 py-4'

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,117 +1,117 @@
-import * as React from "react"
+import * as React from 'react'
 
-import { cn } from "@/utils/cn"
+import { cn } from '@/utils/cn'
 
 const Table = React.forwardRef<
-  HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement>
+	HTMLTableElement,
+	React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
-    <table
-      ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
-      {...props}
-    />
-  </div>
+	// <div className="relative w-full overflow-auto">
+	<table
+		ref={ref}
+		className={cn('w-full caption-bottom text-sm', className)}
+		{...props}
+	/>
+	// </div>
 ))
-Table.displayName = "Table"
+Table.displayName = 'Table'
 
 const TableHeader = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
+	HTMLTableSectionElement,
+	React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+	<thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
 ))
-TableHeader.displayName = "TableHeader"
+TableHeader.displayName = 'TableHeader'
 
 const TableBody = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
+	HTMLTableSectionElement,
+	React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <tbody
-    ref={ref}
-    className={cn("[&_tr:last-child]:border-0", className)}
-    {...props}
-  />
+	<tbody
+		ref={ref}
+		className={cn('[&_tr:last-child]:border-0', className)}
+		{...props}
+	/>
 ))
-TableBody.displayName = "TableBody"
+TableBody.displayName = 'TableBody'
 
 const TableFooter = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
+	HTMLTableSectionElement,
+	React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <tfoot
-    ref={ref}
-    className={cn(
-      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
-      className
-    )}
-    {...props}
-  />
+	<tfoot
+		ref={ref}
+		className={cn(
+			'border-t bg-muted/50 font-medium [&>tr]:last:border-b-0',
+			className
+		)}
+		{...props}
+	/>
 ))
-TableFooter.displayName = "TableFooter"
+TableFooter.displayName = 'TableFooter'
 
 const TableRow = React.forwardRef<
-  HTMLTableRowElement,
-  React.HTMLAttributes<HTMLTableRowElement>
+	HTMLTableRowElement,
+	React.HTMLAttributes<HTMLTableRowElement>
 >(({ className, ...props }, ref) => (
-  <tr
-    ref={ref}
-    className={cn(
-      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
-      className
-    )}
-    {...props}
-  />
+	<tr
+		ref={ref}
+		className={cn(
+			'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+			className
+		)}
+		{...props}
+	/>
 ))
-TableRow.displayName = "TableRow"
+TableRow.displayName = 'TableRow'
 
 const TableHead = React.forwardRef<
-  HTMLTableCellElement,
-  React.ThHTMLAttributes<HTMLTableCellElement>
+	HTMLTableCellElement,
+	React.ThHTMLAttributes<HTMLTableCellElement>
 >(({ className, ...props }, ref) => (
-  <th
-    ref={ref}
-    className={cn(
-      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
-      className
-    )}
-    {...props}
-  />
+	<th
+		ref={ref}
+		className={cn(
+			'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+			className
+		)}
+		{...props}
+	/>
 ))
-TableHead.displayName = "TableHead"
+TableHead.displayName = 'TableHead'
 
 const TableCell = React.forwardRef<
-  HTMLTableCellElement,
-  React.TdHTMLAttributes<HTMLTableCellElement>
+	HTMLTableCellElement,
+	React.TdHTMLAttributes<HTMLTableCellElement>
 >(({ className, ...props }, ref) => (
-  <td
-    ref={ref}
-    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
-    {...props}
-  />
+	<td
+		ref={ref}
+		className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
+		{...props}
+	/>
 ))
-TableCell.displayName = "TableCell"
+TableCell.displayName = 'TableCell'
 
 const TableCaption = React.forwardRef<
-  HTMLTableCaptionElement,
-  React.HTMLAttributes<HTMLTableCaptionElement>
+	HTMLTableCaptionElement,
+	React.HTMLAttributes<HTMLTableCaptionElement>
 >(({ className, ...props }, ref) => (
-  <caption
-    ref={ref}
-    className={cn("mt-4 text-sm text-muted-foreground", className)}
-    {...props}
-  />
+	<caption
+		ref={ref}
+		className={cn('mt-4 text-sm text-muted-foreground', className)}
+		{...props}
+	/>
 ))
-TableCaption.displayName = "TableCaption"
+TableCaption.displayName = 'TableCaption'
 
 export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
+	Table,
+	TableHeader,
+	TableBody,
+	TableFooter,
+	TableHead,
+	TableRow,
+	TableCell,
+	TableCaption,
 }


### PR DESCRIPTION
### Summary
This PR introduces a key enhancement to the `data-table` component in our application. The table header has been updated to have a sticky position, improving the user experience when navigating large data sets.

### Changes

- Updated the` data-table` component. The `TableHeader` within this component now has a` sticky` class, which sets its position to sticky. This means that the table header will remain visible at the top of the viewport when the user scrolls down the table. The `top-0` class ensures that the header sticks to the top of the page, and the `bg-secondary` class applies a secondary background color to the header.

Impact
This change will significantly improve the user experience when interacting with the `data-table` component, especially when dealing with large data sets. The sticky table header will allow users to keep track of the column names even when scrolling down the table, making it easier to understand and analyze the data.